### PR TITLE
Field class with ReadOnly Field

### DIFF
--- a/libs/Field.php
+++ b/libs/Field.php
@@ -15,13 +15,14 @@ class Field extends ExportObject {
 	protected $rectangle = array();
 	protected $type = '';
 	
-	protected $exportProps = array('page', 'rectangle', 'type', 'group_id', 'api_id', 'content', 'label', 'required');
+	protected $exportProps = array('page', 'rectangle', 'type', 'group_id', 'api_id', 'content', 'label', 'required', 'read_only');
 
 	public $group_id = null;
 	public $api_id = null;
 	public $content = null;
     public $label = null;
 	public $required = true;
+	public $read_only = false;
 
 	public function __construct($page, $rectangle = array(), $type) {
 		$this->page = $page;
@@ -40,7 +41,9 @@ class Field extends ExportObject {
 	public function setContent($content) {
 		$this->content = $content;
 	}
-
+	public function setReadOnly() {
+		$this->read_only = true;
+	}
 	public function setLabel($label) {
 		$this->label = $label;
 	}


### PR DESCRIPTION
Digisigner has updated their API and now we have the way to make the field ReadOnly. 
Now we can send signature request by prefilling the signer name and details and just make it easy for them to start to sign.  
Digisigner Reference: https://www.digisigner.com/esignature-api/esignature-api-documentation/